### PR TITLE
Fixed updateCurrentPost to only update the current post

### DIFF
--- a/pages/edit-post/[id].js
+++ b/pages/edit-post/[id].js
@@ -36,7 +36,8 @@ function EditPost() {
       .from('posts')
       .update([
           { title, content }
-      ])
+       ])
+      .match({ id })
     router.push('/my-posts')
   }
   return (


### PR DESCRIPTION
When calling updateCurrentPost the post doesn't only update the current post but all the post in the database